### PR TITLE
Added more information on usage

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright {2017} {Doug Toppin}
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -20,17 +20,20 @@ You can also use the AWS CloudFormation templates as a starting point for your o
 For architectural details, best practices, step-by-step instructions, and customization options, see the [deployment guide](https://s3.amazonaws.com/quickstart-reference/redhat/openshift/latest/doc/red-hat-openshift-on-the-aws-cloud.pdf).
 
 To post feedback, submit feature ideas, or report bugs, use the **Issues** section of this GitHub repo.
-If you'd like to submit code for this Quick Start, please review the [AWS Quick Start Contributor's Kit](https://aws-quickstart.github.io/). 
+If you'd like to submit code for this Quick Start, please review the [AWS Quick Start Contributor's Kit](https://aws-quickstart.github.io/).
 
 
 ## Usage
-Using this Quick Start requires credentials for a Red Hat account that includes a subscription for Red Hat OpenShift Enterprise (note that that may require a non-personal email address registration).
+Using this Quick Start requires credentials for a Red Hat account that includes a subscription for Red Hat OpenShift Enterprise.
 
 The default provisioning in this Quick Start will launch 10 m4.xlarge EC2 instances (3 masters, 3 workers, 3 etcd nodes and 1 ansible configuration server).
+Note that these instances cost $0.20 an hour at this time which works out to more than $40 per day so don't do this casually.
 
-If you have a Red Hat account and do not have easy access to the Red Hat subscription manager you can launch an RHEL instance in the AWS to determine if your account includes the necessary subscription and associated Pool ID.
+You may be able to view your subscriptions via your Red Hat account portal.
+If you have a Red Hat account and do not have easy access to the Red Hat subscription manager or portal you can launch an RHEL instance in the AWS to determine if your account includes the necessary subscription and then get the associated Pool ID from it.
 
-Launch an RHEL instance and do the following on it to access your account
+
+If you want to Launch an RHEL instance then do the following on it to access your account
 
     $ sudo subscription-manager register
 
@@ -54,16 +57,11 @@ Unregister the instance with this
 
 **Important**
 This Quick Start will allocate from your subscription entitlements.
-Before you use this ensure that you will not be taking them away from a pool that needs to be available for your company usage. 
+Before you use this ensure that you will not be taking them away from a pool that needs to be available for your company usage.
 
 
 It is a good idea to go to your Red Hat account portal and ensure that your hosts and subscription entitlements have been removed after you are finished with this exercise and your instances have been terminated.
 
-If you do not already have access to a Red Hat account then go to the following to register and get access
+If you do not already have access to a Red Hat account then go to the following to register and get access (note that that may require a non-personal email address for registration)
 
 [https://www.redhat.com/wapps/eval/index.html?evaluation_id=1026](https://www.redhat.com/wapps/eval/index.html?evaluation_id=1026)
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -43,12 +43,21 @@ Now get a list of what is available to you with this
 The output may include a number of sections.
 If the output includes something like ```Red Hat OpenShift Enterprise``` then look for something after it called ```Pool ID: xxx```.
 If you see that value keep it for use with the CloudFormation stack that you will be launching.
-If you do not see anything like the above you will not be able to use this Quick Start.
+You also need to confirm that you have ```Entitlements Available```.
+If that value is zero or does not appear at all that you may not be able to use the Quick Start.
+
 
 Once you are finished with determining what you need you can unregister the host and then terminate the instance.
 Unregister the instance with this
 
     $ sudo subscription-manager unregister
+
+**Important**
+This Quick Start will allocate from your subscription entitlements.
+Before you use this ensure that you will not be taking them away from a pool that needs to be available for your company usage. 
+
+
+It is a good idea to go to your Red Hat account portal and ensure that your hosts and subscription entitlements have been removed after you are finished with this exercise and your instances have been terminated.
 
 If you do not already have access to a Red Hat account then go to the following to register and get access
 

--- a/README.md
+++ b/README.md
@@ -21,3 +21,40 @@ For architectural details, best practices, step-by-step instructions, and custom
 
 To post feedback, submit feature ideas, or report bugs, use the **Issues** section of this GitHub repo.
 If you'd like to submit code for this Quick Start, please review the [AWS Quick Start Contributor's Kit](https://aws-quickstart.github.io/). 
+
+
+## Usage
+Using this Quick Start requires credentials for a Red Hat account that includes a subscription for Red Hat OpenShift Enterprise (note that that may require a non-personal email address registration).
+
+The default provisioning in this Quick Start will launch 10 m4.xlarge EC2 instances (3 masters, 3 workers, 3 etcd nodes and 1 ansible configuration server).
+
+If you have a Red Hat account and do not have easy access to the Red Hat subscription manager you can launch an RHEL instance in the AWS to determine if your account includes the necessary subscription and associated Pool ID.
+
+Launch an RHEL instance and do the following on it to access your account
+
+    $ sudo subscription-manager register
+
+This will prompt you for your account name and password.
+
+Now get a list of what is available to you with this
+
+    $ sudo subscription-manager list --available --all
+
+The output may include a number of sections.
+If the output includes something like ```Red Hat OpenShift Enterprise``` then look for something after it called ```Pool ID: xxx```.
+If you see that value keep it for use with the CloudFormation stack that you will be launching.
+If you do not see anything like the above you will not be able to use this Quick Start.
+
+Once you are finished with determining what you need you can unregister the host and then terminate the instance.
+Unregister the instance with this
+
+    $ sudo subscription-manager unregister
+
+If you do not already have access to a Red Hat account then go to the following to register and get access
+
+[https://www.redhat.com/wapps/eval/index.html?evaluation_id=1026](https://www.redhat.com/wapps/eval/index.html?evaluation_id=1026)
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Quick Start offers two deployment options:
 
 You can also use the AWS CloudFormation templates as a starting point for your own implementation.
 
-![Quick Start architecture for OpenShift Enterprise on AWS](https://d0.awsstatic.com/partner-network/QuickStart/datasheets/redhat-openshift-on-aws-architecture.png)
+![Quick Start architecture for OpenShift Container Platform on AWS](https://d0.awsstatic.com/partner-network/QuickStart/datasheets/redhat-openshift-on-aws-architecture.png)
 
 For architectural details, best practices, step-by-step instructions, and customization options, see the [deployment guide](https://s3.amazonaws.com/quickstart-reference/redhat/openshift/latest/doc/red-hat-openshift-on-the-aws-cloud.pdf).
 


### PR DESCRIPTION
I added some more information about subscriptions, entitlements and some cost information if you think it is helpful to include.
You might consider an option to only run 1 master, 1 node and 1 etcd to reduce the number of entitlements required and reduce the instance cost.
I think that full HA is a good thing to have as a reference on how to do it but also being able to run your own OpenShift environment for learning/testing is very helpful (and affordable).