### PR TITLE
Correct instance types for Etcd & Nodes

### DIFF
--- a/templates/openshift.template
+++ b/templates/openshift.template
@@ -790,7 +790,7 @@
                     "Ref": "SetupRoleProfile"
                 },
                 "InstanceType": {
-                    "Ref": "MasterInstanceType"
+                    "Ref": "EtcdInstanceType"
                 },
                 "SecurityGroups": [{
                     "Ref": "OpenShiftSecurityGroup"
@@ -975,7 +975,7 @@
                     "Ref": "SetupRoleProfile"
                 },
                 "InstanceType": {
-                    "Ref": "MasterInstanceType"
+                    "Ref": "NodeInstanceType"
                 },
                 "SecurityGroups": [{
                     "Ref": "OpenShiftSecurityGroup"


### PR DESCRIPTION
Currently the Etcd and Node instances are spun up with the same type of the Master. this correct's them to use their own types as expected.