### PR TITLE
Add Tokyo Region ap-northeast-1

### DIFF
--- a/templates/openshift.template
+++ b/templates/openshift.template
@@ -465,7 +465,10 @@
             },
             "us-west-2": {
                 "RHEL74HVM": "ami-9fa343e7"
-            }
+            },
+	    "ap-northeast-1": {
+	    	"RHEL74HVM": "ami-30ef0556"
+	    }
         },
         "LinuxAMINameMap": {
             "Redhat-Enterprise-Linux-7": {


### PR DESCRIPTION
Hi, I'd like to add RHEL 7.4 AMI-ID for Tokyo region.