### PR TITLE
Quote password in argument

### DIFF
--- a/templates/openshift.template
+++ b/templates/openshift.template
@@ -1840,7 +1840,7 @@
                                 "chmod 755 ~/redhat_ose-register.sh\n",
                                 "qs_retry_command 25 ~/redhat_ose-register.sh ",
                                 {
-                                    "Fn::Sub": "${RedhatSubscriptionUserName} ${RedhatSubscriptionPassword} ${RedhatSubscriptionPoolID} "
+                                    "Fn::Sub": "${RedhatSubscriptionUserName} '${RedhatSubscriptionPassword}' ${RedhatSubscriptionPoolID} "
                                 },
                                 "\n",
                                 "echo \"========================================================================================================================\"\n",
@@ -2030,7 +2030,7 @@
                                 "chmod 755 ~/redhat_ose-register.sh\n",
                                 "qs_retry_command 25 ~/redhat_ose-register.sh ",
                                 {
-                                    "Fn::Sub": "${RedhatSubscriptionUserName} ${RedhatSubscriptionPassword} ${RedhatSubscriptionPoolID} "
+                                    "Fn::Sub": "${RedhatSubscriptionUserName} '${RedhatSubscriptionPassword}' ${RedhatSubscriptionPoolID} "
                                 },
                                 "\n",
                                 "echo \"========================================================================================================================\"\n",
@@ -2242,7 +2242,7 @@
                                 "chmod 755 ~/redhat_ose-register.sh\n",
                                 "qs_retry_command 25 ~/redhat_ose-register.sh ",
                                 {
-                                    "Fn::Sub": "${RedhatSubscriptionUserName} ${RedhatSubscriptionPassword} ${RedhatSubscriptionPoolID} "
+                                    "Fn::Sub": "${RedhatSubscriptionUserName} '${RedhatSubscriptionPassword}' ${RedhatSubscriptionPoolID} "
                                 },
                                 "\n",
                                 "echo \"========================================================================================================================\"\n",
@@ -3010,7 +3010,7 @@
                                 "chmod 755 ~/redhat_ose-register.sh\n",
                                 "qs_retry_command 20 ~/redhat_ose-register.sh ",
                                 {
-                                    "Fn::Sub": "${RedhatSubscriptionUserName} ${RedhatSubscriptionPassword} ${RedhatSubscriptionPoolID} "
+                                    "Fn::Sub": "${RedhatSubscriptionUserName} '${RedhatSubscriptionPassword}' ${RedhatSubscriptionPoolID} "
                                 },
                                 "\n",
                                 "echo \"========================================================================================================================\"\n",


### PR DESCRIPTION
The password could contain special chars that don't interact with a
shell very well. (For example &)