### PR TITLE
Add AWSCloudFormationReadOnlyAccess policy to `SetupRole`

### DIFF
--- a/templates/openshift.template
+++ b/templates/openshift.template
@@ -815,6 +815,7 @@ Resources:
       Path: /
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
+        - arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
       Policies:
         - PolicyName: aws-quick-start-s3-policy
           PolicyDocument:


### PR DESCRIPTION
This fixes the permissions issue raised in #135.
I haven't tested this e2e yet, please be aware.