### PR TITLE
Fixes the name of the CWevent

### DIFF
--- a/templates/openshift.template
+++ b/templates/openshift.template
@@ -1781,7 +1781,7 @@ Resources:
     Properties:
       Description: CWEvent rule to trigger OpenShift Scaling scripts within the Ansible
         config server. (AWS QuickStart)
-      Name: OpenshiftQuickstart-TriggerAnsibleScaling
+      Name: !Sub "OpenshiftQuickstart-TriggerAnsibleScaling-${ClusterName}"
       State: ENABLED
       EventPattern:
         source:


### PR DESCRIPTION
it currently prevents to deploy more than one cluster per AWS account.