### PR TITLE
changing ELB health check from /console to /api 

### DIFF
--- a/templates/openshift-master.template
+++ b/templates/openshift-master.template
@@ -277,14 +277,14 @@ Parameters:
     Type: String
   NumberOfMaster:
     Default: '3'
-    Description: This Deployment requires 3 OpenShift Master instances
+    Description: This Deployment requires at least 3 OpenShift Master instances
     Type: Number
-    AllowedValues: [ '3' ]
+    MinValue: '3'
   NumberOfEtcd:
     Default: '3'
-    Description: This Deployment requires 3 OpenShift Etcd instances
+    Description: This Deployment requires at least 3 OpenShift Etcd instances
     Type: Number
-    AllowedValues: [ '3' ]
+    MinValue: '3'
   NumberOfNodes:
     Default: '3'
     Description: The desired capacity for the OpenShift node instances

--- a/templates/openshift-master.template
+++ b/templates/openshift-master.template
@@ -278,13 +278,13 @@ Parameters:
   NumberOfMaster:
     Default: '3'
     Description: This Deployment requires at least 3 OpenShift Master instances
-    Type: Number
-    MinValue: '3'
+    Type: String
+    AllowedPattern: '^[3579]$|(^[1-9]+[13579]$)'
   NumberOfEtcd:
     Default: '3'
     Description: This Deployment requires at least 3 OpenShift Etcd instances
-    Type: Number
-    MinValue: '3'
+    Type: String
+    AllowedPattern: '^[3579]$|(^[1-9]+[13579]$)'
   NumberOfNodes:
     Default: '3'
     Description: The desired capacity for the OpenShift node instances

--- a/templates/openshift.template
+++ b/templates/openshift.template
@@ -1577,7 +1577,7 @@ Resources:
                 - !Ref 'ACMCertificateEmail'
             - !Ref AWS::NoValue
       HealthCheck:
-        Target: HTTPS:443/console/
+        Target: HTTPS:443/api/
         HealthyThreshold: '2'
         UnhealthyThreshold: '3'
         Interval: '30'

--- a/templates/openshift.template
+++ b/templates/openshift.template
@@ -271,14 +271,12 @@ Parameters:
     Default: '3'
     Description: This Deployment requires 3 OpenShift Master instances
     Type: Number
-    AllowedValues:
-      - '3'
+    MinValue: '3'
   NumberOfEtcd:
     Default: '3'
     Description: This Deployment requires 3 OpenShift Etcd instances
     Type: Number
-    AllowedValues:
-      - '3'
+    MinValue: '3'
   NumberOfNodes:
     Default: '3'
     Description: The desired capacity for the OpenShift node instances

--- a/templates/openshift.template
+++ b/templates/openshift.template
@@ -270,13 +270,13 @@ Parameters:
   NumberOfMaster:
     Default: '3'
     Description: This Deployment requires 3 OpenShift Master instances
-    Type: Number
-    MinValue: '3'
+    Type: String
+    AllowedPattern: '^[3579]$|(^[1-9]+[13579]$)'
   NumberOfEtcd:
     Default: '3'
     Description: This Deployment requires 3 OpenShift Etcd instances
-    Type: Number
-    MinValue: '3'
+    Type: String
+    AllowedPattern: '^[3579]$|(^[1-9]+[13579]$)'
   NumberOfNodes:
     Default: '3'
     Description: The desired capacity for the OpenShift node instances


### PR DESCRIPTION
to remove the dependency on the webconsole being up. This now checks that the `api` endpoint is accessible, which should be the case if the api server is 'up'. If not, the master should be considered 'down'.