### PR TITLE
Using the ansible 2.6.5-1 rpm from ansible

### DIFF
--- a/scripts/ansibleconfigserver_bootstrap.sh
+++ b/scripts/ansibleconfigserver_bootstrap.sh
@@ -13,7 +13,7 @@ qs_retry_command 25 aws s3 cp ${QS_S3URI}scripts/redhat_ose-register-${OCP_VERSI
 chmod 755 ~/redhat_ose-register.sh
 qs_retry_command 20 ~/redhat_ose-register.sh ${RH_USER} ${RH_PASS} ${RH_POOLID}
 
-qs_retry_command 10 yum -y install ansible-2.4.6.0 yum-versionlock
+qs_retry_command 10 yum -y install https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.6.5-1.el7.ans.noarch.rpm yum-versionlock
 sed -i 's/#host_key_checking = False/host_key_checking = False/g' /etc/ansible/ansible.cfg
 yum versionlock add ansible
 yum repolist -v | grep OpenShift


### PR DESCRIPTION
Recently the extras and epel repos' versions of ansible has changed. There is ansible version 2.7, but that isn't compatible with openshift-ansible. There is also ansible 2.4, but again, that is not compatible with openshift-ansible either. To avoid issues like this in the future, and to resolve this one I propose the rpm is pulled directly from ansible.