### PR TITLE
Bugfix Issue-104 :: Python unicode translation into Ansible inventory

### DIFF
--- a/scripts/scaling/aws_openshift_quickstart/utils.py
+++ b/scripts/scaling/aws_openshift_quickstart/utils.py
@@ -459,9 +459,9 @@ class InventoryScaling(object):
             cls.nodes_to_add[category] = []
         # Pruning down to category only.
         cat_results = {
-            'succeeded': [x for x in succeeded if x in cls.nodes_to_add[category]],
-            'failed': [x for x in failed if x in cls.nodes_to_add[category]],
-            'unreachable': [x for x in unreachable if x in cls.nodes_to_add[category]]
+            'succeeded': [x.encode('ascii', 'ignore') for x in succeeded if x in cls.nodes_to_add[category]],
+            'failed': [x.encode('ascii', 'ignore') for x in failed if x in cls.nodes_to_add[category]],
+            'unreachable': [x.encode('ascii', 'ignore') for x in unreachable if x in cls.nodes_to_add[category]]
         }
         cls.ansible_results[category] = cat_results
         cls.log.info("- [{}] playbook run results: {}".format(category, cat_results))


### PR DESCRIPTION
Unicode translation was failing, causing `!!python/unicode` to be added literally to hostnames in Ansible inventory when scaling up.

Same issue as:
https://github.com/aws-quickstart/quickstart-redhat-openshift/issues/104
Before:
```
    nodes:
      hosts:
        ip-10-0-0-66.us-west-2.compute.internal:
          instance_id: i-xxxx
          openshift_node_group_name: node-config-compute-infra
        ip-10-0-51-106.us-west-2.compute.internal: *id001
        !!python/unicode 'ip-10-0-51-63.us-west-2.compute.internal':
          instance_id: i-xxxx
          openshift_node_group_name: node-config-compute-infra
        ip-10-0-7-117.us-west-2.compute.internal: *id002
        ip-10-0-76-211.us-west-2.compute.internal: *id003
        !!python/unicode 'ip-10-0-85-40.us-west-2.compute.internal':
          instance_id: i-xxxx
          openshift_node_group_name: node-config-compute-infra
    provision_in_progress:

```

After:
```
    nodes:
      hosts:
        ip-10-0-1-149.us-west-2.compute.internal:
          instance_id: i-xxxx
          openshift_node_group_name: node-config-compute-infra
        ip-10-0-51-106.us-west-2.compute.internal: *id001
        ip-10-0-61-214.us-west-2.compute.internal:
          instance_id: i-xxxx
          openshift_node_group_name: node-config-compute-infra
        ip-10-0-7-117.us-west-2.compute.internal: *id002
        ip-10-0-71-240.us-west-2.compute.internal:
          instance_id: i-xxxx
          openshift_node_group_name: node-config-compute-infra
        ip-10-0-76-211.us-west-2.compute.internal: *id003
```