### PR TITLE
Change minimal MasterInstanceType

### DIFF
--- a/templates/openshift-master.template
+++ b/templates/openshift-master.template
@@ -274,7 +274,7 @@ Parameters:
   MasterInstanceType:
     Default: m4.xlarge
     AllowedValues:
-      - t2.large
+      - t2.xlarge
       - m4.xlarge
       - m4.2xlarge
       - m4.4xlarge


### PR DESCRIPTION
There is openshift.template as nested stack and in that template minimal MasterInstanceType is t2.xlarge, so we can't use t2.large in this template (it looks like a typo)