### PR TITLE
Add get_secret function for unsubscribe_node in utils.py

### DIFF
--- a/scripts/scaling/aws_openshift_quickstart/utils.py
+++ b/scripts/scaling/aws_openshift_quickstart/utils.py
@@ -331,7 +331,8 @@ class InventoryScaling(object):
     @classmethod
     def get_secret(cls):
         cls.log.debug("Secret")
-        region = requests.get('http://169.254.169.254/latest/meta-data/placement/availability-zone')
+        identity = requests.get('http://169.254.169.254/latest/dynamic/instance-identity/document').text
+        region = json.loads(identity)['region']
         region_name = region.text[:-1]
         cf = boto3.client('cloudformation', region_name)
         secret_id = cf.describe_stack_resource(StackName=InventoryConfig.stack_id, LogicalResourceId='RedhatSubscriptionSecret')['StackResourceDetail']['PhysicalResourceId']

--- a/scripts/scaling/aws_openshift_quickstart/utils.py
+++ b/scripts/scaling/aws_openshift_quickstart/utils.py
@@ -8,6 +8,7 @@ import json
 import os
 import operator
 import yaml
+import ast
 from aws_openshift_quickstart.logger import LogUtil
 
 
@@ -326,7 +327,22 @@ class InventoryScaling(object):
             if 'UUID' in local_instance.tags[i]['Key']:
                 yield {'key':local_instance.tags[i]['Key'], 'value': local_instance.tags[i]['Value']}
             i += 1
-
+    
+    @classmethod
+    def get_secret(cls):
+        cls.log.debug("Secret")
+        region = requests.get('http://169.254.169.254/latest/meta-data/placement/availability-zone')
+        region_name = region.text[:-1]
+        secrets = boto3.client('secretsmanager', region_name)
+        for secret in secrets.list_secrets()['SecretList']:
+            for tag in secret['Tags']:
+                if tag['Key']=='aws:cloudformation:stack-id' and tag['Value']==InventoryConfig.stack_id:
+                    for tag in secret['Tags']:
+                        if tag['Key']=='aws:cloudformation:logical-id' and tag['Value']=='RedhatSubscriptionSecret':
+                            secret_name = secret['Name']
+                            secret_value = secrets.get_secret_value(SecretId=secret_name)['SecretString']
+                            return {'user': ast.literal_eval(secret_value)['user'], 'password': ast.literal_eval(secret_value)['password']}
+    
     @classmethod
     def unsubscribe_nodes(cls, node):
         """
@@ -339,9 +355,10 @@ class InventoryScaling(object):
             tags = cls.get_UUID(node_key)
             for tag in tags:
                 cls.log.debug("[{}] / Value [{}] - Tag".format(tag['key'], tag['value']))
-                unsubscribe_url = 'http://subscription.rhn.redhat.com/subscription/consumers/' + tag['value']
+                unsubscribe_url = 'https://subscription.rhn.redhat.com/subscription/consumers/' + tag['value']
         cls.log.debug(unsubscribe_url)
-        response = requests.delete(unsubscribe_url, verify='/etc/rhsm/ca/redhat-uep.pem')
+        auth = cls.get_secret()
+        response = requests.delete(unsubscribe_url, verify='/etc/rhsm/ca/redhat-uep.pem', auth=(auth['user'],auth['password']))
         cls.log.debug("[{}]".format(response.text))
 
     @classmethod


### PR DESCRIPTION
During OpenShift node scale in, I found the unsubscription was not working. Thanks for #201 solution to unsubscribe Openshift node successfully, however the auth needs to be hardcoded. Therefore get_secret function is added to eliminate this issue.

The get_secret function is added (line 331-340) to obtain Red Hat Subscription Secret for unsubscribe_node function. "import ast" (line 11) is needed to convert unicode to dict in (line 340). Also, unsubscribe_url is updated from http to https (line 354) and auth is added in response (line 356-357) in unsubscribe_nodes function.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
