### PR TITLE
[Scaler] Fix for race condition in node unsubscribe workflow

### DIFF
--- a/scripts/scaling/aws_openshift_quickstart/utils.py
+++ b/scripts/scaling/aws_openshift_quickstart/utils.py
@@ -332,8 +332,7 @@ class InventoryScaling(object):
     def get_secret(cls):
         cls.log.debug("Secret")
         identity = requests.get('http://169.254.169.254/latest/dynamic/instance-identity/document').text
-        region = json.loads(identity)['region']
-        region_name = region.text[:-1]
+        region_name = json.loads(identity)['region']
         cf = boto3.client('cloudformation', region_name)
         secret_id = cf.describe_stack_resource(StackName=InventoryConfig.stack_id, LogicalResourceId='RedhatSubscriptionSecret')['StackResourceDetail']['PhysicalResourceId']
         secrets = boto3.client('secretsmanager', region_name)


### PR DESCRIPTION
This PR fixes a race condition in the node unsubscribe workflow. 

Previouly the `region` was returned as a bytes-like object, then converted to text.
Currently it's converted to unicorn before return, so no `.text` was being returned.