### PR TITLE
Adds support for OpenShift 4.5 and fixes some bugs, updates the cloudformation-cli library for Python

### DIFF
--- a/functions/source/OpenShiftResource/Dockerfile
+++ b/functions/source/OpenShiftResource/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3
 WORKDIR /build
 COPY requirements.txt Makefile .rpdk-config awsqs-openshift-manager.json /build/
-COPY cloudformation_cli_python_lib /build/cloudformation_cli_python_lib/
 COPY src /build/src/
 RUN apt-get update && apt-get install zip && make build
 CMD mkdir -p /output/ && mv /build/awsqs-openshift-manager.zip /output/

--- a/functions/source/OpenShiftResource/awsqs-openshift-manager.json
+++ b/functions/source/OpenShiftResource/awsqs-openshift-manager.json
@@ -3,8 +3,7 @@
     "description": "Manages an OpenShift Cluster. Generates Ignition Configuation to help with installation or manages the bootstrap process",
     "definitions": {
         "Arn": {
-            "type": "string",
-            "pattern": "^arn:aws(-(cn|gov))?:[a-z-]+:(([a-z]+-)+[0-9])?:([0-9]{12})?:[^.]+$"
+            "type": "string"
         }
     },
     "properties": {

--- a/functions/source/OpenShiftResource/requirements.txt
+++ b/functions/source/OpenShiftResource/requirements.txt
@@ -1,2 +1,2 @@
-./cloudformation_cli_python_lib/
+cloudformation-cli-python-lib>=2.1.3
 ruamel.yaml==0.16.10

--- a/functions/source/OpenShiftResource/src/awsqs_openshift_manager/openshift.py
+++ b/functions/source/OpenShiftResource/src/awsqs_openshift_manager/openshift.py
@@ -250,7 +250,13 @@ def bootstrap_post_process(oc, kubeconfig_path, remove_builtin_ingress=False, do
     with open(ingress_yaml_path, 'w') as f:
         f.write(ingress_yaml)
     LOG.debug('Ingress YAML: %s', ingress_yaml)
-    run_process(f'{oc} --config {kubeconfig_path} replace --force --wait -f {ingress_yaml_path}')
+    try:
+        run_process(f'{oc} --config {kubeconfig_path} replace --force --wait -f {ingress_yaml_path}')
+    except subprocess.CalledProcessError as e:
+        if 'AlreadyExists' in e.stderr:
+            LOG.info('Caught Exception: Command exited with nonzero because resource already exists. Continuing as normal.')
+        else:
+            raise
     LOG.info('Finished Post-Process steps')
 
 

--- a/templates/openshift-main-existing-vpc.template.yaml
+++ b/templates/openshift-main-existing-vpc.template.yaml
@@ -409,7 +409,7 @@ Parameters:
     Description: OpenShift version to deploy
     Default: '4.3'
     Type: String
-    AllowedValues: [ '3.11', '4.3' ]
+    AllowedValues: [ '3.11', '4.3', '4.5' ]
   VPCCIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
@@ -937,7 +937,7 @@ Conditions:
       - !Ref ClusterName
       - ""
   OS4:
-    !Or [ !Equals [!Ref OpenshiftContainerPlatformVersion, '4.2'], !Equals [!Ref OpenshiftContainerPlatformVersion, '4.3']]
+    !Or [ !Equals [!Ref OpenshiftContainerPlatformVersion, '4.2'], !Equals [!Ref OpenshiftContainerPlatformVersion, '4.3'], !Equals [!Ref OpenshiftContainerPlatformVersion, '4.5']]
   OS3: !Equals [!Ref OpenshiftContainerPlatformVersion, '3.11']
   UseCustomDomain: !And
     - !Not
@@ -985,6 +985,11 @@ Mappings:
     "4.3":
       OpenShiftMirrorURL:  "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"
       OpenShiftVersionNum: "4.3.21"
+      OpenShiftInstallBinary: "openshift-install"
+      OpenShiftClientBinary: "openshift-client"
+    "4.5":
+      OpenShiftMirrorURL:  "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"
+      OpenShiftVersionNum: "4.5.16"
       OpenShiftInstallBinary: "openshift-install"
       OpenShiftClientBinary: "openshift-client"
 Outputs:

--- a/templates/openshift-main.template.yaml
+++ b/templates/openshift-main.template.yaml
@@ -355,7 +355,7 @@ Parameters:
     Description: OpenShift version to deploy
     Default: '4.3'
     Type: String
-    AllowedValues: [ '3.11', '4.3' ]
+    AllowedValues: [ '3.11', '4.3', '4.5' ]
   VPCCIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
@@ -890,7 +890,7 @@ Conditions:
       - !Ref ClusterName
       - ""
   OS4:
-    !Or [ !Equals [!Ref OpenshiftContainerPlatformVersion, '4.2'], !Equals [!Ref OpenshiftContainerPlatformVersion, '4.3']]
+    !Or [ !Equals [!Ref OpenshiftContainerPlatformVersion, '4.2'], !Equals [!Ref OpenshiftContainerPlatformVersion, '4.3'], !Equals [!Ref OpenshiftContainerPlatformVersion, '4.5']]
   OS3: !Equals [!Ref OpenshiftContainerPlatformVersion, '3.11']
   UseCustomDomain: !And
     - !Not
@@ -938,6 +938,11 @@ Mappings:
     "4.3":
       OpenShiftMirrorURL:  "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"
       OpenShiftVersionNum: "4.3.21"
+      OpenShiftInstallBinary: "openshift-install"
+      OpenShiftClientBinary: "openshift-client"
+    "4.5":
+      OpenShiftMirrorURL:  "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"
+      OpenShiftVersionNum: "4.5.16"
       OpenShiftInstallBinary: "openshift-install"
       OpenShiftClientBinary: "openshift-client"
 Outputs:

--- a/templates/openshift4/os4.template.yaml
+++ b/templates/openshift4/os4.template.yaml
@@ -192,6 +192,7 @@ Parameters:
     Type: String
     AllowedValues:
       - '4.3'
+      - '4.5'
   VPCID:
     Description: ID of your existing VPC for deployment
     Type: AWS::EC2::VPC::Id
@@ -627,61 +628,79 @@ Mappings:
       Value: '42'
     '4.3':
       Value: '43'
+    '4.5':
+      Value: '45'
   RhcosAmiMap:
     # 4.2  - rhcos-42.80.20191002.0-hvm
     # 4.3  - rhcos-43.81.202001142154.0-hvm
     'us-east-1':
       "42": ami-01e7fdcb66157b224
       "43": ami-06f85a7940faa3217
+      "45": ami-077ede5bed2e431ea
     us-east-2:
       "42": ami-0bc59aaa7363b805d
       "43": ami-04a79d8d7cfa540cc
+      "45": ami-0f4ecf819275850dd
     us-west-1:
       "42": ami-0ba912f53c1fdcdf0
       "43": ami-0633b392e8eff25e7
+      "45": ami-0c4990e435bc6c5fe
     us-west-2:
       "42": ami-08e10b201e19fd5e7
       "43": ami-0d231993dddc5cd2e
+      "45": ami-000d6e92357ac605c
     sa-east-1:
       "42": ami-03f6b71e93e630dab
       "43": ami-0c80d785b30eef121
+      "45": ami-08e62f746b94950c1
     eu-west-3:
       "42": ami-058ad17da14ff4d0d9
       "43": ami-0049e16104f360df6
+      "45": ami-0e817e26f638a71ac
     eu-west-2:
       "42": ami-00c74e593125e0096
       "43": ami-0eef98c447b85ffcd
+      "45": ami-0e610e967a62dbdfa
     eu-west-1:
       "42": ami-04370efd78434697b
       "43": ami-0e95125b57fa63b0d
+      "45": ami-0bdd69d8e7cd18188
     eu-north-1:
       "42": ami-0175e9c9d258cc11d
       "43": ami-06b7087b2768f644a
     eu-central-1:
       "42": ami-092b69120ecf915ed
       "43": ami-0ceea534b63224411
+      "45": ami-0309c9d2fadcb2d5a
     ca-central-1:
       "42": ami-04419691da69850cf
       "43": ami-0f6d943a1fa9172fd
+      "45": ami-012bc4ee3b6c673bc
     ap-southeast-2:
       "42": ami-0391e92574fb09e08
       "43": ami-08929f33bfab49b83
+      "45": ami-0a5b99ab2234a4e6a
     ap-southeast-1:
-      "42": ami-0d76ac0ebaac29e404
+      "42": ami-0d76ac0ebaac29e40
       "43": ami-086b93722336bd1d9
+      "45": ami-03b46cc4b1518c5a8
     ap-south-1:
       "42": ami-0bd772ba746948d9a
       "43": ami-0bf62e963a473068e
+      "45": ami-0754b15d212830477
     ap-northeast-2:
       "42": ami-014514ae47679721b
       "43": ami-0ba4f9a0358bcb44a
+      "45": ami-09e4cd700276785d2
     ap-northeast-1:
       "42": ami-0426ca3481a088c7b
       "43": ami-023d0452866845125
+      "45": ami-0530d04240177f118
     me-south-1:
       "43": ami-0b03ea038629fd02e
       # No AMI for RHCOS 4.2 in me-south-1
       "42": ''
+      "45": ami-024117d7c87b7ff08
 Outputs:
   OpenShiftUI:
     Description: The URL OpenShiftUI


### PR DESCRIPTION
Fixes #270 #269 

* Changes the OpenShift custom resource build process to use >=2.1.3 of the cloudformation-cli-python package. This should resolve many of the issues reported in #270 
* Adds support for using v4.5 of the QuickStart

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
