### PR TITLE
add build dir scripts to allow publishing to s3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 .taskcat
 taskcat_outputs
 .taskcat-backup
-build/
+output/
 functions/packages
 
 # Lambda

--- a/build/lambda_package.sh
+++ b/build/lambda_package.sh
@@ -1,0 +1,22 @@
+#!/bin/sh -e
+ONLY=$1
+cd functions/source/
+for d in * ; do
+    if [ "${ONLY}" == "" ] ; then  CUR_RESOURCE_PATH=$d ; else CUR_RESOURCE_PATH=$ONLY; fi
+    if [ "${CUR_RESOURCE_PATH}" == "$d" ] ; then
+      n=$(echo $d| tr '[:upper:]' '[:lower:]')
+      cd $d
+      if [ -z "$ECR_BUILD_CACHE" ]; then
+        docker build -t $n .
+      else
+        docker build --cache-from ${ECR_BUILD_CACHE}:$n -t $n .
+      fi
+      docker rm $n > /dev/null 2>&1 || true
+      docker run -i --name $n $n
+      mkdir -p ../../packages/$d/
+      docker cp $n:/output/. ../../packages/$d/
+      docker rm $n > /dev/null
+      cd ../
+    fi
+  done
+cd ../../

--- a/build/s3_sync.py
+++ b/build/s3_sync.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+from sys import argv
+
+import boto3
+import logging
+
+from taskcat._s3_sync import S3Sync, LOG
+
+LOG.setLevel(logging.INFO)
+
+bucket_name = argv[1]
+bucket_region = argv[2]
+bucket_profile = argv[3]
+key_prefix = argv[4]
+source_path = argv[5]
+object_acl = argv[6]
+
+client = boto3.Session(profile_name=bucket_profile).client('s3', region_name=bucket_region)
+
+S3Sync(client, bucket_name, key_prefix, source_path, object_acl)


### PR DESCRIPTION
*Issue: https://github.com/aws-quickstart/quickstart-redhat-openshift/issues/291*

*Description of changes:* The Makefile is missing the publish target and the scripts it calls to build and publish in the build/ directory.
* I adjusted the .gitignore file to add the build directory and ignore the output directory
* I copied the scripts from other quickstarts into the build directory to allow for publishing


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
